### PR TITLE
ci: automatically draft a release on tags with the binaries

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Install Antlr & other apt packages.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,8 @@ name: .NET
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - "*"
   pull_request:
     branches: [ "master" ]
 
@@ -28,6 +30,36 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
 
-    - name: Build all binaries
+    - name: Build Executables
       run: |
         ./build-release.sh
+
+    - name: Upload Executables
+      uses: actions/upload-artifact@v3
+      with:
+        name: bin
+        path: |
+          ./bin/ReleaseZipped
+        retention-days: 1
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Draft the release
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          gzip: folders
+          draft: true
+          files: >
+            ./bin/win-x64.zip
+            ./bin/linux-x64.zip
+            ./bin/linux-musl-x64.zip
+            ./bin/linux-arm64.zip
+            ./bin/osx-x64.zip
+            ./bin/osx-arm64.zip

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,3 +27,7 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+
+    - name: Build all binaries
+      run: |
+        ./build-release.sh


### PR DESCRIPTION
Fixes #17 
After the merge, a new tag should be created to trigger the release.

Here is an example of what is created on tags:
https://github.com/aminya/iro4cli/releases/tag/test1